### PR TITLE
Switch timestamps to CET timezone

### DIFF
--- a/agents/controller_agent.py
+++ b/agents/controller_agent.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
+from utils.time_utils import cet_now
+
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
 
@@ -35,7 +37,7 @@ class ControllerAgent:
         All events are logged into the workflow JSONL file.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
         meta = meta or {}
 
@@ -49,7 +51,7 @@ class ControllerAgent:
                         event_type="error",
                         agent_name="ControllerAgent",
                         agent_version="1.0.0",
-                        timestamp=datetime.utcnow(),
+                        timestamp=cet_now(),
                         step_id=f"controller_step_{step_idx}",
                         prompt_version=None,
                         status="error",
@@ -69,7 +71,7 @@ class ControllerAgent:
                     event_type="controller_delegate",
                     agent_name="ControllerAgent",
                     agent_version="1.0.0",
-                    timestamp=datetime.utcnow(),
+                    timestamp=cet_now(),
                     step_id=f"controller_step_{step_idx}",
                     prompt_version=step.get("prompt_version"),
                     status="in_progress",
@@ -90,7 +92,7 @@ class ControllerAgent:
                 event_type="workflow_complete",
                 agent_name="ControllerAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="controller_done",
                 prompt_version=None,
                 status="success",
@@ -109,7 +111,7 @@ class ControllerAgent:
                 event_type="error",
                 agent_name="ControllerAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="controller_error",
                 prompt_version=None,
                 status="error",

--- a/agents/extract/feature_extraction_agent.py
+++ b/agents/extract/feature_extraction_agent.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
+from utils.time_utils import cet_now
+
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
 from utils.openai_client import OpenAIClient
@@ -45,7 +47,7 @@ class FeatureExtractionAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:
@@ -66,7 +68,7 @@ class FeatureExtractionAgent:
                 event_type="feature_extraction",
                 agent_name="FeatureExtractionAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="feature_extraction",
                 prompt_version=base_name,
                 status="success",
@@ -86,7 +88,7 @@ class FeatureExtractionAgent:
                 event_type="error",
                 agent_name="FeatureExtractionAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="feature_extraction",
                 prompt_version=base_name,
                 status="error",

--- a/agents/llm_prompt_scorer.py
+++ b/agents/llm_prompt_scorer.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
+from utils.time_utils import cet_now
+
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
 from utils.openai_client import OpenAIClient
@@ -74,7 +76,7 @@ class LLMPromptScorer:
         Logs the entire process as an AgentEvent in a centralized JSONL workflow log.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:
@@ -110,7 +112,7 @@ class LLMPromptScorer:
                 event_type="llm_prompt_score",
                 agent_name="LLMPromptScorer",
                 agent_version="2.1.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="scoring",
                 prompt_version=base_name,
                 status="success",
@@ -130,7 +132,7 @@ class LLMPromptScorer:
                 event_type="error",
                 agent_name="LLMPromptScorer",
                 agent_version="2.1.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="scoring",
                 prompt_version=base_name,
                 status="error",

--- a/agents/matchmaking/company_match_agent.py
+++ b/agents/matchmaking/company_match_agent.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
+from utils.time_utils import cet_now
+
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
 from utils.openai_client import OpenAIClient
@@ -45,7 +47,7 @@ class CompanyMatchAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:
@@ -66,7 +68,7 @@ class CompanyMatchAgent:
                 event_type="company_match",
                 agent_name="CompanyMatchAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="company_match",
                 prompt_version=base_name,
                 status="success",
@@ -86,7 +88,7 @@ class CompanyMatchAgent:
                 event_type="error",
                 agent_name="CompanyMatchAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="company_match",
                 prompt_version=base_name,
                 status="error",

--- a/agents/matchmaking/contact_match_agent.py
+++ b/agents/matchmaking/contact_match_agent.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
+from utils.time_utils import cet_now
+
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
 from utils.openai_client import OpenAIClient
@@ -45,7 +47,7 @@ class ContactMatchAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:
@@ -66,7 +68,7 @@ class ContactMatchAgent:
                 event_type="contact_match",
                 agent_name="ContactMatchAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="contact_match",
                 prompt_version=base_name,
                 status="success",
@@ -86,7 +88,7 @@ class ContactMatchAgent:
                 event_type="error",
                 agent_name="ContactMatchAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="contact_match",
                 prompt_version=base_name,
                 status="error",

--- a/agents/matchmaking/crm_sync_agent.py
+++ b/agents/matchmaking/crm_sync_agent.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
+from utils.time_utils import cet_now
+
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
 
@@ -37,7 +39,7 @@ class CRMSyncAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:
@@ -54,7 +56,7 @@ class CRMSyncAgent:
                 event_type="crm_sync",
                 agent_name="CRMSyncAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="crm_sync",
                 prompt_version=base_name,
                 status="success",
@@ -74,7 +76,7 @@ class CRMSyncAgent:
                 event_type="error",
                 agent_name="CRMSyncAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="crm_sync",
                 prompt_version=base_name,
                 status="error",

--- a/agents/ops/cost_monitor_agent.py
+++ b/agents/ops/cost_monitor_agent.py
@@ -12,6 +12,7 @@ Notes   :
 
 from typing import Dict, Any, Optional
 from datetime import datetime
+from utils.time_utils import cet_now
 from utils.schemas import AgentEvent
 from utils.event_logger import write_event_log
 from pathlib import Path
@@ -45,7 +46,7 @@ class CostMonitorAgent:
             event_type="cost_monitor",
             agent_name=self.agent_name,
             agent_version=self.agent_version,
-            timestamp=datetime.utcnow(),
+            timestamp=cet_now(),
             step_id=f"{base_name}_v{prompt_version}_it{iteration}",
             prompt_version=prompt_version,
             meta=meta or {},

--- a/agents/prompt_improvement_agent.py
+++ b/agents/prompt_improvement_agent.py
@@ -16,6 +16,8 @@ Author  : Konstantin Milonas with support from AI Copilot
 from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
+
+from utils.time_utils import cet_now
 import re
 
 from utils.schemas import AgentEvent
@@ -110,7 +112,7 @@ class PromptImprovementAgent:
         Logs all events into the centralized workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:
@@ -134,7 +136,7 @@ class PromptImprovementAgent:
                 event_type="prompt_improvement",
                 agent_name="PromptImprovementAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="improvement",
                 prompt_version=base_name,
                 status="success",
@@ -155,7 +157,7 @@ class PromptImprovementAgent:
                 event_type="error",
                 agent_name="PromptImprovementAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="improvement",
                 prompt_version=base_name,
                 status="error",

--- a/agents/prompt_quality_agent.py
+++ b/agents/prompt_quality_agent.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
+from utils.time_utils import cet_now
+
 from utils.openai_client import OpenAIClient
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
@@ -53,7 +55,7 @@ class PromptQualityAgent:
         Ensures structured feedback (list) for downstream improvement agent.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:
@@ -83,7 +85,7 @@ class PromptQualityAgent:
                 event_type="error",
                 agent_name="PromptQualityAgent",
                 agent_version="1.4.3",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="quality_evaluation",
                 prompt_version=base_name,
                 status="error",

--- a/agents/reasoning/industry_class_agent.py
+++ b/agents/reasoning/industry_class_agent.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
+from utils.time_utils import cet_now
+
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
 from utils.openai_client import OpenAIClient
@@ -45,7 +47,7 @@ class IndustryClassAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:
@@ -66,7 +68,7 @@ class IndustryClassAgent:
                 event_type="industry_classification",
                 agent_name="IndustryClassAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="industry_classification",
                 prompt_version=base_name,
                 status="success",
@@ -86,7 +88,7 @@ class IndustryClassAgent:
                 event_type="error",
                 agent_name="IndustryClassAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="industry_classification",
                 prompt_version=base_name,
                 status="error",

--- a/agents/reasoning/usecase_detection_agent.py
+++ b/agents/reasoning/usecase_detection_agent.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
+from utils.time_utils import cet_now
+
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
 from utils.openai_client import OpenAIClient
@@ -45,7 +47,7 @@ class UsecaseDetectionAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:
@@ -66,7 +68,7 @@ class UsecaseDetectionAgent:
                 event_type="usecase_detection",
                 agent_name="UsecaseDetectionAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="usecase_detection",
                 prompt_version=base_name,
                 status="success",
@@ -86,7 +88,7 @@ class UsecaseDetectionAgent:
                 event_type="error",
                 agent_name="UsecaseDetectionAgent",
                 agent_version="1.0.0",
-                timestamp=datetime.utcnow(),
+                timestamp=cet_now(),
                 step_id="usecase_detection",
                 prompt_version=base_name,
                 status="error",

--- a/cli/run_prompt_lifecycle.py
+++ b/cli/run_prompt_lifecycle.py
@@ -17,6 +17,8 @@ import sys
 from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
+
+from utils.time_utils import cet_now
 import argparse
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -48,7 +50,7 @@ def evaluate_and_improve_prompt(
     path: Path, layer: str = "feature_setup", openai_client=None
 ):
     # --- Generate unique workflow_id for this run
-    workflow_id = f"{datetime.utcnow().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+    workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
     logger = JsonlEventLogger(workflow_id, Path("logs/workflows"))
 
     base_version = parse_version_from_yaml(path)

--- a/prompt_quality/cli/render_and_validate_template.py
+++ b/prompt_quality/cli/render_and_validate_template.py
@@ -70,6 +70,7 @@ import os
 import re
 import sys
 from datetime import datetime
+from utils.time_utils import cet_now
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(**file**), "..")))
 
@@ -138,7 +139,7 @@ print("\nPrompt Preview:\n----------------")
 print(full_prompt_with_input)
 
 print("\nQuality Checks:\n----------------")
-timestamp = datetime.now().strftime("%Y-%m-%dT%H_%M_%S")
+timestamp = cet_now().strftime("%Y-%m-%dT%H_%M_%S")
 log_path = os.path.join(LOG_DIR, f"prompt_check_{language}_{timestamp}.txt")
 
 with open(log_path, "w", encoding="utf-8") as log:

--- a/prompt_quality/cli/validate_prompt_quality_cli.py
+++ b/prompt_quality/cli/validate_prompt_quality_cli.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 import json
 from datetime import datetime
+from utils.time_utils import cet_now
 from colorama import init, Fore, Style
 
 # Projektpfad für Imports sicherstellen
@@ -41,7 +42,7 @@ def validate_prompt(prompt: str):
 
 
 def log_results(prompt, results, explanation_map, show_score):
-    timestamp = datetime.now().strftime("%y%m%d_%I:%M %p")
+    timestamp = cet_now().strftime("%y%m%d_%I:%M %p")
     log_path = os.path.join(LOG_DIR, f"prompt_check_en_{timestamp}.txt")
     violations = []
     score = 0.0
@@ -82,7 +83,7 @@ def json_output(prompt, results):
         "score": score,
         "violations": violations,
         "checks": results,
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": cet_now().isoformat(),
     }
     print(json.dumps(output, indent=2, ensure_ascii=False))
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,2 @@
 # Makes 'utils' a Python package
+from .time_utils import cet_now

--- a/utils/archive_utils.py
+++ b/utils/archive_utils.py
@@ -13,6 +13,7 @@ Notes   :
 import os
 import shutil
 from datetime import datetime
+from utils.time_utils import cet_now
 
 
 def archive_prompt_file(file_path: str, archive_dir: str = "archive") -> str:
@@ -31,7 +32,7 @@ def archive_prompt_file(file_path: str, archive_dir: str = "archive") -> str:
     if not os.path.isdir(archive_dir):
         os.makedirs(archive_dir)
     base_name = os.path.basename(file_path)
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = cet_now().strftime("%Y%m%d_%H%M%S")
     archived_file = os.path.join(archive_dir, f"{base_name}.{timestamp}.bak")
     shutil.copy2(file_path, archived_file)
     return archived_file

--- a/utils/schemas.py
+++ b/utils/schemas.py
@@ -13,6 +13,7 @@ Notes   :
 from pydantic import BaseModel, Field
 from typing import Dict, Any, List, Optional
 from datetime import datetime
+from .time_utils import cet_now
 
 
 class PromptQualityResult(BaseModel):
@@ -63,7 +64,7 @@ class AgentEvent(BaseModel):
     event_type: str
     agent_name: str
     agent_version: str
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=cet_now)
     step_id: str
     prompt_version: Optional[str] = None
     meta: Dict[str, Any] = Field(default_factory=dict)

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,0 +1,17 @@
+"""
+Time utilities with Central European Time (CET) defaults.
+
+Provides a single function ``cet_now`` to obtain the current
+``datetime`` in CET using Python's ``zoneinfo`` module.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+# Reuse this zoneinfo object across calls
+CET_ZONE = ZoneInfo("Europe/Berlin")
+
+
+def cet_now() -> datetime:
+    """Return the current time in Central European Time (CET)."""
+    return datetime.now(CET_ZONE)

--- a/workflows/template_prompt_loop.py
+++ b/workflows/template_prompt_loop.py
@@ -25,6 +25,7 @@ from agents.prompt_improvement_agent import PromptImprovementAgent
 import json
 import shutil
 from datetime import datetime
+from utils.time_utils import cet_now
 
 
 def run_template_loop(
@@ -45,7 +46,7 @@ def run_template_loop(
         score, feedback = quality_agent.run(prompt_text)
         print(f"\n📊 Score: {score}")
 
-        timestamp = datetime.now().strftime("%y%m%d_%H%M")
+        timestamp = cet_now().strftime("%y%m%d_%H%M")
         feedback_path = parent_dir / f"{base_name}_v{version}_feedback_{timestamp}.json"
         feedback_path.write_text(json.dumps(feedback, indent=2, ensure_ascii=False))
 


### PR DESCRIPTION
## Summary
- add `time_utils.cet_now` helper for Central European Time
- default `AgentEvent.timestamp` to `cet_now`
- update agents and utilities to generate CET timestamps
- expose `cet_now` via `utils` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `ruff check .` *(fails with SyntaxError on existing files)*
- `make format` *(fails: Cannot parse some files)*

------
https://chatgpt.com/codex/tasks/task_e_68420b7ea2a4832baa66a8f7cb856c04