### PR TITLE
Add config flag and pydantic compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The system orchestrates autonomous LLM agents for evaluation, improvement, valid
 
 - **Agentic Prompt Lifecycle:** Automated processing from RAW to PRODUCTION (incl. research loop, scoring, improvement, controller supervision).
 - **Strict Versioning:** Complete support for semantic versioning, auto-increment, promotion, patch bump, and archiving.
-- **Flexible Scoring:** Each quality check (raw, template, feature, usecase, industry, company, contact) uses its own scoring matrix (type-safe via Enum). Raw prompts can optionally be scored via the LLM itself.
+ - **Flexible Scoring:** Each quality check (raw, template, feature, usecase, industry, company, contact) uses its own scoring matrix (type-safe via Enum). Raw prompts can optionally be scored via the LLM itself by enabling the `use_llm` flag in `LLMPromptScorer`.
 - **Pluggable Agents:** Clearly separated, easily extensible agent classes (Quality, Improvement, Controller, Extraction, Matchmaking, Reasoning, Ops).
 - **Event Logging & Audit Trail:** Every action, score, or improvement is logged as an AgentEvent in JSON with timestamp and version.
 - **Archiving:** Automatic archiving of prompts after every stage transition.
@@ -110,6 +110,7 @@ THRESHOLD=0.90
 MAX_ITERATIONS=3
 HUBSPOT_API_KEY=your-key   # Optional, if CRM sync is enabled
 LOG_LEVEL=INFO
+USE_LLM_SCORING=true      # Enable LLM-based checks for RAW prompts
 ```
 
 ## Getting Started

--- a/config/thresholds.yaml
+++ b/config/thresholds.yaml
@@ -4,3 +4,4 @@ usecase_quality: 0.90
 industry_quality: 0.90
 company_quality: 0.90
 max_retries: 3
+use_llm_scoring: true

--- a/utils/jsonl_event_logger.py
+++ b/utils/jsonl_event_logger.py
@@ -20,7 +20,11 @@ class JsonlEventLogger:
             )
 
         with open(self.log_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(event.model_dump(), default=default) + "\n")
+            if hasattr(event, "model_dump"):
+                event_dict = event.model_dump()
+            else:  # pydantic<2
+                event_dict = event.dict()
+            f.write(json.dumps(event_dict, default=default) + "\n")
 
 
 """


### PR DESCRIPTION
## Summary
- support pydantic v1 in `JsonlEventLogger`
- expose `use_llm` flag in README and .env template
- document `use_llm_scoring` config in thresholds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421c09c018832b941b82beaa7f223e