### PR TITLE
Enable global LLM scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ python cli/run_prompt_lifecycle.py --file prompts/00-raw/feature_determination.y
 ## Advanced
 
 - **Scoring Matrix:** Use via Enum `ScoringMatrixType` (in `utils/scoring_matrix_types.py`), type-checked, customizable per agent.
-- **LLM-based scoring:** When `use_llm=True` the quality agent sends prompt and criterion text to OpenAI and interprets the reply as pass/fail (enabled for RAW prompts).
+- **LLM-based scoring:** When `use_llm=True` the quality agent sends prompt and criterion text to OpenAI and interprets the reply as pass/fail (enabled for all prompt stages).
 - **Archiving:** Prompts are moved after each status change to `prompts/99-archive/` (with timestamp, stage, version).
 - **Test & CI:** All core functions have unit tests, integration tests for the agent pipeline (pytest-ready).
 

--- a/agents/prompt_quality_agent.py
+++ b/agents/prompt_quality_agent.py
@@ -47,7 +47,7 @@ class PromptQualityAgent:
             self.scoring_matrix,
             self.llm,
             log_dir=self.log_dir,
-            use_llm=self.scoring_matrix_type == ScoringMatrixType.RAW,
+            use_llm=True,
         )
 
     def run(


### PR DESCRIPTION
## Summary
- always enable LLM-based scoring in `PromptQualityAgent`
- update README to note LLM checks run for all prompt stages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421f359d18832b85fc43e0ce02d614