### PR TITLE
Fix CET timestamp filenames

### DIFF
--- a/agents/controller_agent.py
+++ b/agents/controller_agent.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
@@ -37,7 +37,7 @@ class ControllerAgent:
         All events are logged into the workflow JSONL file.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
         meta = meta or {}
 

--- a/agents/extract/feature_extraction_agent.py
+++ b/agents/extract/feature_extraction_agent.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
@@ -47,7 +47,7 @@ class FeatureExtractionAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:

--- a/agents/llm_prompt_scorer.py
+++ b/agents/llm_prompt_scorer.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
@@ -100,7 +100,7 @@ class LLMPromptScorer:
         Logs the entire process as an AgentEvent in a centralized JSONL workflow log.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:

--- a/agents/matchmaking/company_match_agent.py
+++ b/agents/matchmaking/company_match_agent.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
@@ -47,7 +47,7 @@ class CompanyMatchAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:

--- a/agents/matchmaking/contact_match_agent.py
+++ b/agents/matchmaking/contact_match_agent.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
@@ -47,7 +47,7 @@ class ContactMatchAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:

--- a/agents/matchmaking/crm_sync_agent.py
+++ b/agents/matchmaking/crm_sync_agent.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
@@ -39,7 +39,7 @@ class CRMSyncAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:

--- a/agents/prompt_improvement_agent.py
+++ b/agents/prompt_improvement_agent.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 import re
 
 from utils.schemas import AgentEvent
@@ -126,7 +126,7 @@ class PromptImprovementAgent:
         Logs all events into the centralized workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:

--- a/agents/prompt_quality_agent.py
+++ b/agents/prompt_quality_agent.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 
 from utils.openai_client import OpenAIClient
 from utils.schemas import AgentEvent
@@ -59,7 +59,7 @@ class PromptQualityAgent:
         Ensures structured feedback (list) for downstream improvement agent.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:

--- a/agents/reasoning/industry_class_agent.py
+++ b/agents/reasoning/industry_class_agent.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
@@ -47,7 +47,7 @@ class IndustryClassAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:

--- a/agents/reasoning/usecase_detection_agent.py
+++ b/agents/reasoning/usecase_detection_agent.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
@@ -47,7 +47,7 @@ class UsecaseDetectionAgent:
         All events are logged to the workflow JSONL log.
         """
         if workflow_id is None:
-            workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+            workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
         logger = JsonlEventLogger(workflow_id, self.log_dir)
 
         try:

--- a/cli/run_prompt_lifecycle.py
+++ b/cli/run_prompt_lifecycle.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_for_filename
 import argparse
 
 from utils.openai_client import OpenAIClient
@@ -50,7 +50,7 @@ improvement_strategy_lookup = {
 def evaluate_and_improve_prompt(
     path: Path, layer: str = "feature_setup", openai_client=None
 ):
-    workflow_id = f"{cet_now().isoformat(timespec='seconds').replace(':', '-')}_workflow_{uuid4().hex[:6]}"
+    workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
     logger = JsonlEventLogger(workflow_id, Path("logs/workflows"))
 
     iteration = 0

--- a/prompt_quality/cli/validate_prompt_quality_cli.py
+++ b/prompt_quality/cli/validate_prompt_quality_cli.py
@@ -6,7 +6,7 @@ import json
 # Projektpfad für Imports sicherstellen
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from utils.time_utils import cet_now
+from utils.time_utils import cet_now, timestamp_iso
 from colorama import init, Fore, Style
 
 from prompt_quality.validators.validate_prompt_quality_en import validate_prompt_en
@@ -83,7 +83,7 @@ def json_output(prompt, results):
         "score": score,
         "violations": violations,
         "checks": results,
-        "timestamp": cet_now().isoformat(),
+        "timestamp": timestamp_iso(),
     }
     print(json.dumps(output, indent=2, ensure_ascii=False))
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,2 +1,2 @@
 # Makes 'utils' a Python package
-from .time_utils import cet_now
+from .time_utils import cet_now, timestamp_for_filename, timestamp_iso

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -15,3 +15,13 @@ CET_ZONE = ZoneInfo("Europe/Berlin")
 def cet_now() -> datetime:
     """Return the current time in Central European Time (CET)."""
     return datetime.now(CET_ZONE)
+
+
+def timestamp_for_filename() -> str:
+    """Return CET timestamp suitable for filenames (no timezone)."""
+    return cet_now().strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def timestamp_iso() -> str:
+    """Return CET timestamp in ISO format without timezone offset."""
+    return cet_now().strftime("%Y-%m-%dT%H:%M:%S")


### PR DESCRIPTION
## Summary
- provide CET timestamp helpers without timezone offsets
- use those helpers when creating workflow logs
- adjust CLI output for JSON timestamp

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ee8cc944832b89654ea3a3da1a86