### PR TITLE
Add python-dotenv dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ USE_LLM_SCORING=true      # Enable LLM-based checks for RAW prompts
 # Setup
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
-pip install -r requirements.txt
+pip install -r requirements.txt  # installs python-dotenv
 
 # Create .env and insert your keys
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ typing-inspection==0.4.1
 typing_extensions==4.13.2
 urllib3==2.4.0
 wheel==0.45.1
+python-dotenv>=0.21


### PR DESCRIPTION
## Summary
- add `python-dotenv>=0.21` to requirements
- mention python-dotenv in the setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ff34e438832b9d513792c45cb61d