### PR TITLE
Add dual scoring for PromptQualityAgent

### DIFF
--- a/tests/test_prompt_quality_agent.py
+++ b/tests/test_prompt_quality_agent.py
@@ -32,20 +32,22 @@ class TestPromptQualityAgent(unittest.TestCase):
     def test_matrix_score(self):
         prompt = "Fill the fields: {name}, {desc}."
         event = self._run_prompt(prompt)
-        score = event.payload.get("score", 0)
+        score = event.payload.get("matrix_score", 0)
         self.assertTrue(0 <= score <= 1)
 
     def test_llm_score(self):
         prompt = "Clear and concise: {foo}, {bar}."
         event = self._run_prompt(prompt)
-        score = event.payload.get("score", 0)
+        score = event.payload.get("llm_score", 0)
         self.assertTrue(0 <= score <= 1)
 
     def test_hybrid_score(self):
         prompt = "Brief: {a}, {b}."
         event = self._run_prompt(prompt)
-        score = event.payload.get("score", 0)
-        self.assertTrue(0 <= score <= 1)
+        matrix_score = event.payload.get("matrix_score", 0)
+        llm_score = event.payload.get("llm_score", 0)
+        self.assertTrue(0 <= matrix_score <= 1)
+        self.assertTrue(0 <= llm_score <= 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_run_prompt_lifecycle.py
+++ b/tests/test_run_prompt_lifecycle.py
@@ -17,7 +17,14 @@ class TestLifecycleDecision(unittest.TestCase):
         temp_dir, path = self._make_temp_prompt()
         try:
             pq_event = MagicMock()
-            pq_event.payload = {"passed": False, "pass_threshold": 0.9, "score": 0.5, "feedback": []}
+            pq_event.payload = {
+                "passed_llm": False,
+                "passed_matrix": False,
+                "llm_score": 0.5,
+                "matrix_score": 0.8,
+                "llm_feedback": [],
+                "matrix_feedback": [],
+            }
             with patch("cli.run_prompt_lifecycle.PromptQualityAgent") as MockPQ, \
                 patch("cli.run_prompt_lifecycle.PromptImprovementAgent") as MockPI, \
                 patch("cli.run_prompt_lifecycle.JsonlEventLogger") as MockLogger:
@@ -35,7 +42,14 @@ class TestLifecycleDecision(unittest.TestCase):
         temp_dir, path = self._make_temp_prompt()
         try:
             pq_event = MagicMock()
-            pq_event.payload = {"passed": True, "pass_threshold": 0.9, "score": 0.95, "feedback": []}
+            pq_event.payload = {
+                "passed_llm": True,
+                "passed_matrix": True,
+                "llm_score": 0.95,
+                "matrix_score": 0.95,
+                "llm_feedback": [],
+                "matrix_feedback": [],
+            }
             with patch("cli.run_prompt_lifecycle.PromptQualityAgent") as MockPQ, \
                 patch("cli.run_prompt_lifecycle.PromptImprovementAgent") as MockPI, \
                 patch("cli.run_prompt_lifecycle.JsonlEventLogger") as MockLogger:


### PR DESCRIPTION
## Summary
- call `LLMPromptScorer` twice in `PromptQualityAgent`
- include matrix and LLM scores in one event
- adapt prompt lifecycle logic to new payload
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435153d070832bbbc7f69651432b14