### PR TITLE
Allow env THRESHOLD for prompt scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,15 @@ graph LR
 
 ```env
 OPENAI_API_KEY=sk-...
-THRESHOLD=0.90
+THRESHOLD=0.90        # Optional. Minimum score for LLMPromptScorer (defaults to 0.9)
 MAX_ITERATIONS=3
 HUBSPOT_API_KEY=your-key   # Optional, if CRM sync is enabled
 LOG_LEVEL=INFO
 USE_LLM_SCORING=true      # Enable LLM-based checks for RAW prompts
 ```
+
+`THRESHOLD` controls the minimum score required for a prompt to pass quality
+checks. When not set, the default of `0.9` is used.
 
 ## Getting Started
 

--- a/agents/llm_prompt_scorer.py
+++ b/agents/llm_prompt_scorer.py
@@ -15,6 +15,7 @@ Author  : Konstantin Milonas with support from AI Copilot
 from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
+import os
 
 from utils.time_utils import cet_now, timestamp_for_filename
 
@@ -113,7 +114,7 @@ class LLMPromptScorer:
 
             # Calculate weighted, normalized score
             score = self._weighted_score(criteria_results)
-            threshold = 0.9  # Set globally or via config/env
+            threshold = float(os.getenv("THRESHOLD", "0.9"))
 
             passed = score >= threshold
 

--- a/tests/test_llm_prompt_scorer.py
+++ b/tests/test_llm_prompt_scorer.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+import tempfile
+from pathlib import Path
+
+from agents.llm_prompt_scorer import LLMPromptScorer
+
+
+class TestLLMPromptScorerEnvThreshold(unittest.TestCase):
+    def setUp(self):
+        self.matrix = {
+            "a": {"weight": 1.0, "required_snippet": "a", "feedback": "f"},
+            "b": {"weight": 1.0, "required_snippet": "b", "feedback": "f"},
+        }
+        self.scorer = LLMPromptScorer(self.matrix)
+
+    def test_custom_threshold(self):
+        os.environ["THRESHOLD"] = "0.4"
+        with tempfile.NamedTemporaryFile("w+", delete=False) as tmp:
+            tmp.write("only a present")
+            tmp.flush()
+            path = Path(tmp.name)
+        try:
+            event = self.scorer.run(path, "t", 0)
+        finally:
+            path.unlink()
+            del os.environ["THRESHOLD"]
+        self.assertEqual(event.payload["pass_threshold"], 0.4)
+        self.assertTrue(event.payload["passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make `LLMPromptScorer` read threshold from the `THRESHOLD` env var
- document the `THRESHOLD` setting in the README
- test environment threshold handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843554574f4832b88d95c22f941f8fd