### PR TITLE
Simplify prompt scoring with LLM-only checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The system orchestrates autonomous LLM agents for evaluation, improvement, valid
 
 - **Agentic Prompt Lifecycle:** Automated processing from RAW to PRODUCTION (incl. research loop, scoring, improvement, controller supervision).
 - **Strict Versioning:** Complete support for semantic versioning, auto-increment, promotion, patch bump, and archiving.
- - **Flexible Scoring:** Each quality check (raw, template, feature, usecase, industry, company, contact) uses its own scoring matrix (type-safe via Enum). Raw prompts can optionally be scored via the LLM itself by enabling the `use_llm` flag in `LLMPromptScorer`.
+- **Flexible Scoring:** Each quality check (raw, template, feature, usecase, industry, company, contact) uses its own scoring matrix (type-safe via Enum). Every criterion is validated via the LLM.
 - **Pluggable Agents:** Clearly separated, easily extensible agent classes (Quality, Improvement, Controller, Extraction, Matchmaking, Reasoning, Ops).
 - **Event Logging & Audit Trail:** Every action, score, or improvement is logged as an AgentEvent in JSON with timestamp and version.
 - **Archiving:** Automatic archiving of prompts after every stage transition.
@@ -106,15 +106,11 @@ graph LR
 
 ```env
 OPENAI_API_KEY=sk-...
-THRESHOLD=0.90        # Optional. Minimum score for LLMPromptScorer (defaults to 0.9)
 MAX_ITERATIONS=3
 HUBSPOT_API_KEY=your-key   # Optional, if CRM sync is enabled
 LOG_LEVEL=INFO
-USE_LLM_SCORING=true      # Enable LLM-based checks for RAW prompts
 ```
 
-`THRESHOLD` controls the minimum score required for a prompt to pass quality
-checks. When not set, the default of `0.9` is used.
 
 ## Getting Started
 
@@ -135,7 +131,7 @@ python cli/run_prompt_lifecycle.py --file prompts/00-raw/feature_determination.y
 ## Advanced
 
 - **Scoring Matrix:** Use via Enum `ScoringMatrixType` (in `utils/scoring_matrix_types.py`), type-checked, customizable per agent.
-- **LLM-based scoring:** When `use_llm=True` the quality agent sends prompt and criterion text to OpenAI and interprets the reply as pass/fail (enabled for all prompt stages).
+ - **LLM-based scoring:** The quality agent sends each criterion to OpenAI and interprets the reply as pass or fail for that criterion.
 - **Archiving:** Prompts are moved after each status change to `prompts/99-archive/` (with timestamp, stage, version).
 - **Test & CI:** All core functions have unit tests, integration tests for the agent pipeline (pytest-ready).
 

--- a/agents/llm_prompt_scorer.py
+++ b/agents/llm_prompt_scorer.py
@@ -7,15 +7,12 @@ Logging : Logs all events (including errors) into a centralized workflow JSONL l
 Author  : Konstantin Milonas with support from AI Copilot
 
 # Notes:
-# - Implements true weighted, normalized scoring per matrix.
-# - Event log always includes: criteria_results, score, pass_threshold, passed, feedback.
-# - To extend for LLM-based checks, replace the validation logic pro Kriterium.
+# - Uses the LLM to validate each criterion in the scoring matrix.
+# - Event log payload only contains the LLM-derived results per criterion.
 """
 
 from pathlib import Path
-from datetime import datetime
 from uuid import uuid4
-import os
 
 from utils.time_utils import cet_now, timestamp_for_filename
 
@@ -25,79 +22,79 @@ from utils.openai_client import OpenAIClient
 from typing import Optional
 
 
+class LLMUnavailableError(Exception):
+    """Raised when the LLM API cannot be reached."""
+
+
 class LLMPromptScorer:
     def __init__(
         self,
         scoring_matrix: dict,
         openai_client: Optional[OpenAIClient] = None,
         log_dir=Path("logs/workflows"),
-        use_llm: bool = False,
     ):
         """
         scoring_matrix: dict with per-criterion weights, descriptions, and feedbacks
-        openai_client: injected LLM client (not required for base matrix scoring)
+        openai_client: injected LLM client
         log_dir: directory for workflow logs (default: logs/workflows)
-        use_llm: if True, criteria are validated via the injected LLM
         """
         self.scoring_matrix = scoring_matrix
         self.llm = openai_client
         self.log_dir = log_dir
-        self.use_llm = use_llm
 
-    def _evaluate_criteria(self, prompt_content: str) -> dict:
+    def _evaluate_criteria(
+        self,
+        prompt_content: str,
+        logger: JsonlEventLogger,
+        base_name: str,
+        iteration: int,
+    ) -> dict:
         """
         Evaluates all criteria from the scoring matrix against the prompt content.
         Returns a dict: {criterion: bool}
-        Criteria-Check:
-          - If a 'required_snippet' exists, checks for exact presence (case-insensitive).
-          - If not, returns True (or implement real logic per Kriterium).
         """
         results = {}
         for key, rule in self.scoring_matrix.items():
-            if self.use_llm:
-                if self.llm is None:
-                    results[key] = False
-                    continue
-                description = rule.get("description", "")
-                prompt = (
-                    "Does the following prompt meet this criterion?\n"
-                    f"Criterion: {description}\n"
-                    "Answer only with 'PASS' or 'FAIL'.\n\n"
-                    f"Prompt:\n{prompt_content}"
+            if self.llm is None:
+                raise LLMUnavailableError("LLM client not provided")
+
+            description = rule.get("description", "")
+            prompt = (
+                "Does the following prompt meet this criterion?\n"
+                f"Criterion: {description}\n"
+                "Answer only with 'PASS' or 'FAIL'.\n\n"
+                f"Prompt:\n{prompt_content}"
+            )
+            try:
+                response = self.llm.chat_completion(
+                    prompt=prompt,
+                    temperature=0.0,
+                    max_tokens=5,
                 )
-                try:
-                    response = self.llm.chat_completion(
-                        prompt=prompt,
-                        temperature=0.0,
-                        max_tokens=5,
-                    )
-                    answer = response.choices[0].message.get("content", "").strip().lower()
-                    results[key] = answer.startswith("pass")
-                except Exception:
-                    results[key] = False
-            else:
-                snippet = rule.get("required_snippet")
-                if snippet:
-                    results[key] = snippet.lower() in prompt_content.lower()
-                else:
-                    results[key] = True
+                answer = response.choices[0].message.get("content", "").strip().lower()
+                results[key] = answer.startswith("pass")
+            except Exception:
+                error_event = AgentEvent(
+                    event_type="error",
+                    agent_name="LLMPromptScorer",
+                    agent_version="2.2.0",
+                    timestamp=cet_now(),
+                    step_id="scoring",
+                    prompt_version=base_name,
+                    status="error",
+                    payload={"reason": "LLM API unavailable"},
+                    meta={"iteration": iteration, "criterion": key},
+                )
+                logger.log_event(error_event)
+                raise LLMUnavailableError from None
         return results
 
-    def _weighted_score(self, results: dict) -> float:
-        """
-        Calculates the weighted, normalized score for all criteria.
-        """
-        sum_fulfilled = sum(
-            self.scoring_matrix[k]["weight"] for k, v in results.items() if v
-        )
-        sum_total = sum(v["weight"] for v in self.scoring_matrix.values())
-        return sum_fulfilled / sum_total if sum_total > 0 else 0.0
 
     def run(
         self, prompt_path: Path, base_name: str, iteration: int, workflow_id: str = None
     ):
         """
-        Scores a prompt by evaluating all matrix criteria and aggregating weighted score.
+        Scores a prompt by evaluating all matrix criteria via the LLM.
         Logs the entire process as an AgentEvent in a centralized JSONL workflow log.
         """
         if workflow_id is None:
@@ -110,27 +107,12 @@ class LLMPromptScorer:
                 prompt_content = f.read()
 
             # Evaluate criteria
-            criteria_results = self._evaluate_criteria(prompt_content)
-
-            # Calculate weighted, normalized score
-            score = self._weighted_score(criteria_results)
-            threshold = float(os.getenv("THRESHOLD", "0.9"))
-
-            passed = score >= threshold
-
-            # Feedback: collect all feedbacks for unmet criteria
-            feedback = [
-                self.scoring_matrix[k]["feedback"]
-                for k, v in criteria_results.items()
-                if not v
-            ]
+            criteria_results = self._evaluate_criteria(
+                prompt_content, logger, base_name, iteration
+            )
 
             payload = {
                 "criteria_results": criteria_results,
-                "score": score,
-                "pass_threshold": threshold,
-                "passed": passed,
-                "feedback": feedback,
             }
 
             event = AgentEvent(
@@ -150,6 +132,9 @@ class LLMPromptScorer:
             logger.log_event(event)
             return event
 
+        except LLMUnavailableError:
+            # Error already logged in _evaluate_criteria
+            return None
         except Exception as ex:
             import traceback
 


### PR DESCRIPTION
## Summary
- remove `use_llm` branches and snippet scoring
- call the LLM for every criterion and report only those results
- stop lifecycle script when all criteria pass
- update docs for LLM-only scoring

## Testing
- `ruff check agents/llm_prompt_scorer.py agents/prompt_quality_agent.py cli/run_prompt_lifecycle.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445debaff0832ba2523b738a709ea9