### PR TITLE
Remove matrix scoring path

### DIFF
--- a/agents/core/prompt_quality_agent.py
+++ b/agents/core/prompt_quality_agent.py
@@ -1,15 +1,17 @@
-"""Prompt Quality Agent:
-- Bewertet Prompts anhand einer Score-Matrix aus der Config.
-- Nutzt LLM oder regelbasierte Scoring-Matrix.
+"""Prompt Quality Agent used in unit tests.
+
+This simplified agent now only generates a score via a pseudo LLM
+implementation.  Any former matrix based scoring logic has been
+removed so tests rely solely on the single LLM based scorer.
 """
 
 from dataclasses import dataclass
-from typing import Any
 
 
 @dataclass
 class ScoreResult:
     """Simple container for a prompt score."""
+
     total: float
     method: str
 
@@ -17,21 +19,8 @@ class ScoreResult:
 class PromptQualityAgent:
     """Lightweight prompt quality scorer used in unit tests."""
 
-    def __init__(self, scoring_matrix_path: str | None = None) -> None:
-        self.scoring_matrix_path = scoring_matrix_path
-
-    def load_matrix(self) -> dict:
-        if not self.scoring_matrix_path:
-            return {}
-        import json
-
-        with open(self.scoring_matrix_path, encoding="utf-8") as f:
-            return json.load(f)
-
-    def _matrix_score(self, prompt_text: str) -> float:
-        """Return a deterministic score based on placeholder usage."""
-        placeholders = prompt_text.count("{")
-        return min(1.0, placeholders / 3)
+    def __init__(self) -> None:  # pragma: no cover - simple container
+        pass
 
     def _llm_score(self, prompt_text: str) -> float:
         """Return a dummy LLM-based score.
@@ -41,28 +30,8 @@ class PromptQualityAgent:
         """
         return min(1.0, max(0.0, len(prompt_text) / 100))
 
-    def score_prompt(self, prompt_text: str, method: str = "matrix") -> ScoreResult:
-        """Score ``prompt_text`` using the specified method.
+    def score_prompt(self, prompt_text: str) -> ScoreResult:
+        """Score ``prompt_text`` using the pseudo LLM scorer."""
 
-        Parameters
-        ----------
-        prompt_text:
-            Text of the prompt to evaluate.
-        method:
-            ``"matrix"`` (default), ``"llm"`` or ``"hybrid"``.
-        """
-        method = method.lower()
-        if method not in {"matrix", "llm", "hybrid"}:
-            raise ValueError(f"Unknown scoring method: {method}")
-
-        matrix_score = self._matrix_score(prompt_text)
-        llm_score = self._llm_score(prompt_text)
-
-        if method == "matrix":
-            total = matrix_score
-        elif method == "llm":
-            total = llm_score
-        else:  # hybrid
-            total = (matrix_score + llm_score) / 2
-
-        return ScoreResult(total=total, method=method)
+        total = self._llm_score(prompt_text)
+        return ScoreResult(total=total, method="llm")

--- a/cli/run_prompt_lifecycle.py
+++ b/cli/run_prompt_lifecycle.py
@@ -13,7 +13,8 @@ Author  : Konstantin Milonas with support from AI Copilot
 # - Uses improvement_strategy mapping (Enum-based) per layer.
 # - Stops early when no version change or score improvement is minimal.
 # - Automatically activates detailed_feedback on score failure.
-# - Matrix selection now based on stable layer extraction from filename.
+# - Matrix selection only defines the scoring criteria. All scoring is
+#   performed via the LLM scorer.
 """
 
 import sys
@@ -26,8 +27,8 @@ from utils.time_utils import cet_now, timestamp_for_filename
 import argparse
 
 from utils.openai_client import OpenAIClient
-from utils.prompt_versioning import clean_base_name, extract_version
-from utils.semantic_versioning_utils import parse_version_from_yaml, bump
+from utils.prompt_versioning import extract_version
+from utils.semantic_versioning_utils import bump
 from utils.scoring_matrix_types import ScoringMatrixType
 from utils.jsonl_event_logger import JsonlEventLogger
 from utils.schemas import AgentEvent


### PR DESCRIPTION
## Summary
- remove matrix scoring functionality from test agent
- update lifecycle script to document LLM-only scoring
- drop unused imports

## Testing
- `ruff check cli/run_prompt_lifecycle.py agents/core/prompt_quality_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68447a936c9c832b9124f983ac186980