### PR TITLE
Update scoring docs and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ data/outputs/
 *.pdf
 
 # Agentenlogs (erlaube .gitkeep als Platzhalter)
-logs/weighted_score/*
 logs/quality_log/*
 logs/feedback_log/*
 logs/change_log/*

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ python cli/run_prompt_lifecycle.py --file prompts/00-raw/feature_determination.y
 
 - **Scoring Matrix:** Use via Enum `ScoringMatrixType` (in `utils/scoring_matrix_types.py`), type-checked, customizable per agent.
  - **LLM-based scoring:** The quality agent sends each criterion to OpenAI and interprets the reply as pass or fail for that criterion.
+ - If the OpenAI API is unavailable, scoring fails and an error event is logged.
 - **Archiving:** Prompts are moved after each status change to `prompts/99-archive/` (with timestamp, stage, version).
 - **Test & CI:** All core functions have unit tests, integration tests for the agent pipeline (pytest-ready).
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -48,7 +48,7 @@ python run_template_batch.py --all
 │   ├── quality_log/                    # JSON: Dimension -> Issue
 │   ├── feedback_log/                   # Verbesserungsfeedback
 │   ├── change_log/                     # Prompt-Diffs mit Rationale
-│   └── weighted_score/                 # Score-only Files
+│   └── score_log/                      # Score-only Files
 ├── agents/
 │   ├── prompt_quality_agent.py
 │   ├── prompt_improvement_agent.py
@@ -79,7 +79,6 @@ OPENAI_API_KEY=sk-...
 ## 📌 Hinweis
 
 - Du kannst den Controller-Agent so konfigurieren, dass er nach bestimmten Versionen abbricht oder neue Varianten erzeugt.
-- Prompt-Qualität wird über gewichtete Scores berechnet und versioniert abgelegt.
 
 ## 📬 Kontakt
 

--- a/agents/llm_prompt_scorer.py
+++ b/agents/llm_prompt_scorer.py
@@ -35,7 +35,7 @@ class LLMPromptScorer:
         log_dir=Path("logs/workflows"),
     ):
         """
-        scoring_matrix: dict with per-criterion weights, descriptions, and feedbacks
+        scoring_matrix: dict with per-criterion descriptions and feedbacks
         openai_client: injected LLM client
         log_dir: directory for workflow logs (default: logs/workflows)
         """

--- a/agents/ops/cost_monitor_agent.py
+++ b/agents/ops/cost_monitor_agent.py
@@ -6,7 +6,7 @@ Version : 1.0.1
 Author  : Konstantin & AI Copilot
 Notes   :
 - Aggregates API call costs by agent and run.
-- Logs all cost events exclusively to logs/weighted_score/
+- Logs all cost events exclusively to logs/score_log/
 - Designed for integration into pipeline or as a CLI utility.
 """
 
@@ -17,7 +17,7 @@ from utils.schemas import AgentEvent
 from utils.event_logger import write_event_log
 from pathlib import Path
 
-LOG_DIR = Path("logs") / "weighted_score"
+LOG_DIR = Path("logs") / "score_log"
 
 
 class CostMonitorAgent:

--- a/config/scoring/feature_scoring_matrix.py
+++ b/config/scoring/feature_scoring_matrix.py
@@ -7,7 +7,7 @@ Evaluation criteria for prompts used in feature extraction from product data.
 
 Usage:
 - Used by PromptQualityAgent when scoring feature extraction prompts.
-- Each criterion includes a weight and a feedback text for dynamic improvement hints.
+ - Each criterion includes a feedback text for dynamic improvement hints.
 """
 
 SCORING_MATRIX = {

--- a/config/thresholds.yaml
+++ b/config/thresholds.yaml
@@ -4,4 +4,3 @@ usecase_quality: 0.90
 industry_quality: 0.90
 company_quality: 0.90
 max_retries: 3
-use_llm_scoring: true

--- a/docs/README_A2A_Prompt_Workflow.md
+++ b/docs/README_A2A_Prompt_Workflow.md
@@ -58,8 +58,9 @@ This prompt development workflow supports iterative evaluation and improvement w
 1. **Start with a Raw prompt file** (`*_raw_vX.Y.Z.yaml`)
 2. **Log initial prompt state**
 3. **Run `PromptQualityAgent` to evaluate prompt quality**
-4. **Write quality and weighted score logs**
+4. **Write quality and score logs**
 5. **Evaluate if score meets the threshold**
+   - If the OpenAI API is unavailable, scoring fails and an error event is logged.
    - If yes, save prompt as `*_config_vX.Y.Z.yaml` in `01-examples/`
    - If no, run `PromptImprovementAgent` to create improved prompt
 6. **Log improved prompt and feedback**
@@ -75,7 +76,7 @@ All intermediate states are logged in `/logs/` under these categories:
 - `quality_log/`
 - `feedback_log/`
 - `change_log/`
-- `weighted_score/`
+- `score_log/`
 
 Each log entry is a fully validated JSON event for traceability and monitoring.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -13,6 +13,7 @@ Do not use local log files, scattered per-agent logs, or any kind of legacy outp
   - Location: `logs/workflows/`
   - Pattern: `{timestamp}_workflow_{workflow_id}.jsonl`
 - All agent events (success and error) are recorded as structured `AgentEvent` objects, one per line, in the workflow log.
+- If the OpenAI API is unreachable during scoring, the agent logs an error event and the run stops.
 - No more legacy logs in `logs/quality_check/`, `logs/prompt_improvement/`, `logs/controller_decision/`, or any `data/outputs/` directory.
 
 #### What must developers do?


### PR DESCRIPTION
## Summary
- drop `use_llm_scoring` option
- rename weighted score logs to `score_log`
- note API failure behaviour in README and docs
- cleanup references to weights in docs and comments

## Testing
- `pytest -q`
- `ruff check .` *(fails: unrecognized subcommand .)*

------
https://chatgpt.com/codex/tasks/task_e_68447febbf10832b8ee70dbf33133855