### PR TITLE
Add PDF report generation for workflows

### DIFF
--- a/cli/run_prompt_lifecycle.py
+++ b/cli/run_prompt_lifecycle.py
@@ -30,6 +30,7 @@ from utils.prompt_versioning import clean_base_name, extract_version
 from utils.semantic_versioning_utils import bump
 from utils.scoring_matrix_types import ScoringMatrixType
 from utils.jsonl_event_logger import JsonlEventLogger
+from utils.pdf_report_generator import generate_pdf_report
 from utils.schemas import AgentEvent
 from agents.prompt_quality_agent import PromptQualityAgent
 from agents.prompt_improvement_agent import PromptImprovementAgent
@@ -199,6 +200,13 @@ def evaluate_and_improve_prompt(
 
         if iteration >= 7:
             print("⛔️ Max iterations reached. Aborting.")
+
+    # Generate PDF summary of the workflow log
+    try:
+        pdf_path = generate_pdf_report(logger.log_path)
+        print(f"📝 Workflow report saved to: {pdf_path}")
+    except Exception as e:
+        print(f"⚠️ Failed to generate PDF report: {e}")
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ typing_extensions==4.13.2
 urllib3==2.4.0
 wheel==0.45.1
 python-dotenv>=0.21
+Jinja2==3.1.3
+WeasyPrint==61.2

--- a/utils/pdf_report_generator.py
+++ b/utils/pdf_report_generator.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import json
+from typing import Iterable, Dict, Any
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from weasyprint import HTML
+
+
+def load_events(jsonl_path: Path) -> Iterable[Dict[str, Any]]:
+    """Load AgentEvent entries from a JSONL workflow log."""
+    with open(jsonl_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def generate_pdf_report(
+    log_path: Path,
+    output_dir: Path = Path("logs/reports"),
+    template_path: Path = Path("templates/report_template.html"),
+) -> Path:
+    """Render a workflow log as a PDF report and return the created file path."""
+    entries = list(load_events(log_path))
+    env = Environment(
+        loader=FileSystemLoader(template_path.parent),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    template = env.get_template(template_path.name)
+    html_content = template.render(entries=entries)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = output_dir / f"{log_path.stem}_report.pdf"
+    HTML(string=html_content, base_url=str(template_path.parent)).write_pdf(str(pdf_path))
+    return pdf_path
+


### PR DESCRIPTION
## Summary
- generate PDF reports from workflow logs
- call the PDF generator after prompt lifecycle execution
- add Jinja2 and WeasyPrint dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449f374cb8832bad763cced14f6335