### PR TITLE
Adjust JSONL logger output format

### DIFF
--- a/utils/jsonl_event_logger.py
+++ b/utils/jsonl_event_logger.py
@@ -24,10 +24,9 @@ class JsonlEventLogger:
                 event_dict = event.model_dump()
             else:  # pydantic<2
                 event_dict = event.dict()
-            f.write(
-                json.dumps(event_dict, default=default, ensure_ascii=False, indent=2)
-                + "\n"
-            )
+            json_str = json.dumps(event_dict, default=default, ensure_ascii=False)
+            json_str = json_str.replace("\n", "")
+            f.write(json_str + "\n")
 
 
 """


### PR DESCRIPTION
## Summary
- log events without indentation in JSON lines
- strip newline characters from JSON strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844aed33220832bb0006caf7598780a