### PR TITLE
Use generate_pdf_report for prompt quality agent

### DIFF
--- a/agents/prompt_quality_agent.py
+++ b/agents/prompt_quality_agent.py
@@ -136,9 +136,7 @@ Antworte im Format:
 
             # Optional: Create PDF summary report
             try:
-                PDFReportGenerator(Path("templates"), Path("logs/reports")).generate(
-                    workflow_id, [event.model_dump()]
-                )
+                generate_pdf_report(logger.log_path)
             except Exception as report_err:
                 print(f"⚠️ Failed to generate PDF report: {report_err}")
 


### PR DESCRIPTION
## Summary
- call `generate_pdf_report` directly instead of outdated `PDFReportGenerator`
- save PDF summary based on current workflow log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844af857b28832bbd0ae1fc1a2eb0d7