### PR TITLE
Improve placeholder detection logic

### DIFF
--- a/docs/README_A2A_Prompt_Workflow.md
+++ b/docs/README_A2A_Prompt_Workflow.md
@@ -89,6 +89,27 @@ Each log entry is a fully validated JSON event for traceability and monitoring.
 - Keep scoring and configuration files versioned in `config/`.
 - Ensure prompt versions inside files and filenames always match.
 
+### Placeholder Feedback
+
+`PromptQualityAgent` can generate detailed feedback for specific positions in a
+prompt. Placeholders in curly braces remain supported, but you can now also use
+explicit tags (`[[placeholder]]`). Additionally, common YAML fields such as
+`id`, `objective` and `constraints` are automatically evaluated even when they
+contain no braces.
+
+Example snippet:
+
+```yaml
+id: contact_assignment
+objective: >
+  [[objective]]
+constraints:
+  - [[constraints]]
+```
+
+Detected placeholders are listed in the `detailed_feedback` section of the
+quality check result.
+
 ## Deployment Targets
 
 Production prompts (`*_active_vX.Y.Z.yaml`) are ready for deployment to:


### PR DESCRIPTION
## Summary
- expand PromptQualityAgent placeholder search to YAML keys and `[[tag]]` syntax
- document new placeholder feedback options in prompt workflow docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b50324f4832ba56bf2a0c69d32a7