### PR TITLE
Fix prompt lifecycle pass check

### DIFF
--- a/cli/run_prompt_lifecycle.py
+++ b/cli/run_prompt_lifecycle.py
@@ -138,7 +138,7 @@ def evaluate_and_improve_prompt(
 
         weighted_score = pq_event.payload.get("weighted_score", 0.0)
 
-        if pq_event.payload.get("passed_llm") or weighted_score >= PASS_THRESHOLD:
+        if weighted_score >= PASS_THRESHOLD:
             print("✅ Prompt passed quality threshold.")
 
             target_name = current_path.name.replace("_raw_", "_template_").rsplit(


### PR DESCRIPTION
## Summary
- remove dead passed_llm check in lifecycle runner

## Testing
- `python -m py_compile cli/run_prompt_lifecycle.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b68864ac832b93b5a3c88c8e6c89