### PR TITLE
Add quality loop and simplify CLI

### DIFF
--- a/agents/matchmaking/company_match_agent.py
+++ b/agents/matchmaking/company_match_agent.py
@@ -45,6 +45,7 @@ class CompanyMatchAgent:
         iteration: int,
         workflow_id: str = None,
         parent_event_id: str = None,
+        prompt_override: str | None = None,
     ):
         if workflow_id is None:
             workflow_id = f"company_{uuid4().hex[:6]}"
@@ -53,7 +54,7 @@ class CompanyMatchAgent:
         try:
             industries_json = json.dumps(input_data, ensure_ascii=False, indent=2)
 
-            companies_json = self.match_companies(industries_json)
+            companies_json = self.match_companies(industries_json, prompt_override)
             validated = CompaniesMatched(companies=companies_json)
 
             payload = {
@@ -108,12 +109,14 @@ class CompanyMatchAgent:
             logger.log_event(error_event)
             raise
 
-    def match_companies(self, industries_json: str):
+    def match_companies(self, industries_json: str, prompt_override: str | None = None):
         prompt = (
             "Given the following JSON array of industry classes, suggest 3 to 7 example companies (real or plausible for the market) "
             "as a JSON array of company names. Return only the JSON array, no explanations.\n\n"
             f"{industries_json}\n"
         )
+        if prompt_override:
+            prompt = prompt_override
         response = self.llm.chat(prompt=prompt)
         print("🧠 LLM Response (Company):\n", response)
         return json.loads(response)

--- a/agents/reasoning/industry_class_agent.py
+++ b/agents/reasoning/industry_class_agent.py
@@ -46,6 +46,7 @@ class IndustryClassAgent:
         iteration: int,
         workflow_id: str = None,
         parent_event_id: str = None,
+        prompt_override: str | None = None,
     ):
         if workflow_id is None:
             workflow_id = f"industry_{uuid4().hex[:6]}"
@@ -54,7 +55,7 @@ class IndustryClassAgent:
         try:
             usecases_json = json.dumps(input_data, ensure_ascii=False, indent=2)
 
-            industries_json = self.extract_industries(usecases_json)
+            industries_json = self.extract_industries(usecases_json, prompt_override)
             validated = IndustriesExtracted(industries=industries_json)
 
             payload = {
@@ -109,12 +110,14 @@ class IndustryClassAgent:
             logger.log_event(error_event)
             raise
 
-    def extract_industries(self, usecases_json: str):
+    def extract_industries(self, usecases_json: str, prompt_override: str | None = None):
         prompt = (
             "Given the following JSON array of use cases, assign and return relevant industry classes (e.g. NAICS, NACE, or text labels) "
             "as a JSON array of strings. Return only the JSON array, no explanations.\n\n"
             f"{usecases_json}\n"
         )
+        if prompt_override:
+            prompt = prompt_override
         response = self.llm.chat(prompt=prompt)
         print("🧠 LLM Response (Industry):\n", response)
         return json.loads(response)

--- a/agents/reasoning/usecase_detection_agent.py
+++ b/agents/reasoning/usecase_detection_agent.py
@@ -46,6 +46,7 @@ class UsecaseDetectionAgent:
         iteration: int,
         workflow_id: str = None,
         parent_event_id: str = None,
+        prompt_override: str | None = None,
     ):
         if workflow_id is None:
             workflow_id = f"usecase_{uuid4().hex[:6]}"
@@ -55,7 +56,7 @@ class UsecaseDetectionAgent:
             # Prepare JSON string for LLM
             features_json = json.dumps(input_data, ensure_ascii=False, indent=2)
 
-            usecases_json = self.extract_usecases(features_json)
+            usecases_json = self.extract_usecases(features_json, prompt_override)
             validated = UsecasesExtracted(usecases=usecases_json)
 
             payload = {
@@ -110,13 +111,15 @@ class UsecaseDetectionAgent:
             logger.log_event(error_event)
             raise
 
-    def extract_usecases(self, features_json: str):
+    def extract_usecases(self, features_json: str, prompt_override: str | None = None):
         prompt = (
             "Given the following extracted product features as JSON, "
             "infer and return 3 to 7 plausible usage domains (application environments, use cases) as a JSON array of strings. "
             "Do not include explanations, only the JSON list.\n\n"
             f"{features_json}\n"
         )
+        if prompt_override:
+            prompt = prompt_override
         response = self.llm.chat(prompt=prompt)
         print("🧠 LLM Response (Usecase):\n", response)
         return json.loads(response)

--- a/cli/run_orchestration.py
+++ b/cli/run_orchestration.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 import argparse
 from uuid import uuid4
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -15,19 +16,18 @@ from utils.pdf_report_generator import generate_pdf_report
 def main():
     parser = argparse.ArgumentParser(description="Agent Orchestration Runner")
     parser.add_argument(
-        "--sample_file", required=True, help="Path to sample input file (e.g. JSON)"
-    )
-    parser.add_argument("--base_name", required=True, help="Base prompt name")
-    parser.add_argument("--iteration", type=int, default=1, help="Iteration index")
-    parser.add_argument(
-        "--log_dir", default="logs/workflows", help="Workflow log storage directory"
+        "--sample_file",
+        default="data/sample/mini_stock_list.json",
+        help="Path to sample input file (e.g. JSON)",
     )
     args = parser.parse_args()
 
     sample_file = Path(args.sample_file)
-    base_name = args.base_name
-    iteration = args.iteration
-    log_dir = Path(args.log_dir)
+    with open("config/max_retries.yaml", "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    iteration = cfg.get("max_retries", 1)
+    base_name = "feature_setup_template_v0.2.0"
+    log_dir = Path("logs/workflows")
     workflow_id = f"{timestamp_for_filename()}_workflow_{uuid4().hex[:6]}"
     log_path = log_dir / f"{workflow_id}.jsonl"
 

--- a/controller/agent_orchestrator.py
+++ b/controller/agent_orchestrator.py
@@ -13,7 +13,10 @@ from agents.extract.feature_extraction_agent import FeatureExtractionAgent
 from agents.reasoning.usecase_detection_agent import UsecaseDetectionAgent
 from agents.reasoning.industry_class_agent import IndustryClassAgent
 from agents.matchmaking.company_match_agent import CompanyMatchAgent
+from agents.prompt_quality_agent import PromptQualityAgent
+from agents.prompt_improvement_agent import PromptImprovementAgent
 from utils.jsonl_event_logger import JsonlEventLogger
+import yaml
 
 
 class AgentOrchestrator:
@@ -22,6 +25,10 @@ class AgentOrchestrator:
         self.sample_file = sample_file
         self.log_dir = log_dir
         self.openai_client = OpenAIClient()
+
+        with open("config/max_retries.yaml", "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f)
+        self.max_retries = cfg.get("max_retries", 1)
 
         self.feature_agent = FeatureExtractionAgent(
             openai_client=self.openai_client,
@@ -39,6 +46,70 @@ class AgentOrchestrator:
             openai_client=self.openai_client,
             log_dir=self.log_dir,
         )
+        self.quality_agent = PromptQualityAgent(
+            openai_client=self.openai_client,
+            log_dir=self.log_dir,
+        )
+        self.improvement_agent = PromptImprovementAgent(
+            openai_client=self.openai_client,
+            log_dir=self.log_dir,
+        )
+
+    def _run_with_quality(
+        self,
+        agent,
+        input_data,
+        base_name: str,
+        iteration: int,
+        parent_event_id: str | None = None,
+    ):
+        current_event = agent.run(
+            input_data=input_data,
+            base_name=base_name,
+            iteration=iteration,
+            workflow_id=self.workflow_id,
+            parent_event_id=parent_event_id,
+        )
+
+        retries = 0
+        while retries < self.max_retries:
+            quality_event = self.quality_agent.run(
+                input_data=current_event.payload,
+                base_name=base_name,
+                iteration=iteration,
+                workflow_id=self.workflow_id,
+                parent_event_id=current_event.event_id,
+            )
+
+            passed = quality_event.payload["evaluation"]["passed"]
+            if passed:
+                break
+
+            improvement_event = self.improvement_agent.run(
+                {
+                    "original_prompt": base_name,
+                    "output": current_event.payload,
+                    "feedback": quality_event.payload["evaluation"],
+                },
+                base_name=base_name,
+                iteration=iteration,
+                workflow_id=self.workflow_id,
+                parent_event_id=quality_event.event_id,
+            )
+
+            improved_prompt = improvement_event.payload["improved_prompt"]
+            retries += 1
+
+            current_event = agent.run(
+                input_data=input_data,
+                base_name=base_name,
+                iteration=iteration,
+                workflow_id=self.workflow_id,
+                parent_event_id=improvement_event.event_id,
+                prompt_override=improved_prompt,
+            )
+
+        return current_event
 
     def run(self, base_name: str, iteration: int):
         # Load sample data once and pass as input data to agents
@@ -46,51 +117,52 @@ class AgentOrchestrator:
             sample_data = json.load(f)
 
         # Step 1: Feature Extraction
-        feature_event = self.feature_agent.run(
+        feature_event = self._run_with_quality(
+            self.feature_agent,
             input_data=sample_data,
             base_name=base_name.replace(
-                "usecase_detect_template", "feature_setup_template"
+                "usecase_detect_template",
+                "feature_setup_template",
             ),
             iteration=iteration,
-            workflow_id=self.workflow_id,
         )
-
         feature_payload = feature_event.payload
 
         # Step 2: Usecase Detection
-        usecase_event = self.usecase_agent.run(
+        usecase_event = self._run_with_quality(
+            self.usecase_agent,
             input_data=feature_payload,
             base_name=base_name.replace(
-                "feature_setup_template", "usecase_detect_template"
+                "feature_setup_template",
+                "usecase_detect_template",
             ),
             iteration=iteration,
-            workflow_id=self.workflow_id,
             parent_event_id=feature_event.event_id,
         )
-
         usecase_payload = usecase_event.payload
 
         # Step 3: Industry Classification
-        industry_event = self.industry_agent.run(
+        industry_event = self._run_with_quality(
+            self.industry_agent,
             input_data=usecase_payload,
             base_name=base_name.replace(
-                "usecase_detect_template", "industry_class_template"
+                "usecase_detect_template",
+                "industry_class_template",
             ),
             iteration=iteration,
-            workflow_id=self.workflow_id,
             parent_event_id=usecase_event.event_id,
         )
-
         industry_payload = industry_event.payload
 
         # Step 4: Company Assignment
-        company_event = self.company_agent.run(
+        company_event = self._run_with_quality(
+            self.company_agent,
             input_data=industry_payload,
             base_name=base_name.replace(
-                "industry_class_template", "company_assign_template"
+                "industry_class_template",
+                "company_assign_template",
             ),
             iteration=iteration,
-            workflow_id=self.workflow_id,
             parent_event_id=industry_event.event_id,
         )
 


### PR DESCRIPTION
## Summary
- integrate PromptQualityAgent and PromptImprovementAgent in `AgentOrchestrator`
- add `_run_with_quality` helper to re-run agents until quality passes
- support optional `prompt_override` in all agent run methods
- simplify `run_orchestration.py` with defaults for base name, log directory and iteration

## Testing
- `pytest -q`
- `python -m py_compile cli/run_orchestration.py controller/agent_orchestrator.py agents/extract/feature_extraction_agent.py agents/reasoning/usecase_detection_agent.py agents/reasoning/industry_class_agent.py agents/matchmaking/company_match_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6846b99ff858832b992b076590d65cb3