### PR TITLE
Improve industry class JSON parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+- Improve industry_class_agent: extract_industries now parses LLM output using
+  `utils.json_safety.extract_json_array_from_response` for better resilience.

--- a/agents/reasoning/industry_class_agent.py
+++ b/agents/reasoning/industry_class_agent.py
@@ -22,6 +22,7 @@ from utils.time_utils import cet_now
 from utils.schemas import AgentEvent
 from utils.jsonl_event_logger import JsonlEventLogger
 from utils.openai_client import OpenAIClient
+from utils.json_safety import extract_json_array_from_response
 
 
 class IndustriesExtracted(BaseModel):
@@ -120,4 +121,4 @@ class IndustryClassAgent:
             prompt = prompt_override
         response = self.llm.chat(prompt=prompt)
         print("🧠 LLM Response (Industry):\n", response)
-        return json.loads(response)
+        return extract_json_array_from_response(response)


### PR DESCRIPTION
## Summary
- handle extra text around JSON results in `extract_industries`
- add a changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cc219d40832b898db8ffa08b40f9